### PR TITLE
Clamp similarity values between -1.0 and 1.0 to avoid NaNs from acos

### DIFF
--- a/short_gpt/metrics.py
+++ b/short_gpt/metrics.py
@@ -21,6 +21,7 @@ def block_influence(
     sim = sim.diagonal().nan_to_num(nan=0.5)
 
     if angular:
+        sim = torch.clamp(sim, -1.0, 1.0)
         return (torch.arccos(sim) / torch.pi)
 
     return 1 - sim


### PR DESCRIPTION
This pull request makes a minor adjustment to the similarity calculation in the `block_influence` function to ensure numerical stability when using angular metrics.

* Metrics calculation:
  * Added a `torch.clamp` operation to restrict the values of `sim` between -1.0 and 1.0 before applying the arccosine function in the angular metric computation. This prevents errors due to floating point inaccuracies.

I have noticed some NaNs while testing the function, mainly numbers slightly above 1.